### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0+3] - April 18, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.0+2] - April 11, 2023
 
 * Automated dependency updates
@@ -11,6 +16,7 @@
 ## [1.0.0] - April 3rd, 2023
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'screen_streamer'
 description: "A library that can stream an android, ios, etc. Flutter application's screen using WebRTC"
 homepage: 'https://github.com/peiffer-innovations/screen_streamer'
-version: '1.0.0+2'
+version: '1.0.0+3'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -11,11 +11,11 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   flutter_background_service: '^2.4.6'
-  flutter_webrtc: '^0.9.25'
+  flutter_webrtc: '^0.9.26'
   logging: '^1.1.1'
   sdp_transform: '^0.3.2'
-  web_socket_channel: '^2.3.0'
-  web_socket_channel_connect: '^1.0.1+3'
+  web_socket_channel: '^2.4.0'
+  web_socket_channel_connect: '^1.0.1+4'
 
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `flutter_webrtc`: 0.9.25 --> 0.9.26
  * `web_socket_channel`: 2.3.0 --> 2.4.0
  * `web_socket_channel_connect`: 1.0.1+3 --> 1.0.1+4


Analysis Successful



