### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0+11] - June 20, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.0+10] - June 13, 2023
 
 * Automated dependency updates
@@ -51,6 +56,7 @@
 ## [1.0.0] - April 3rd, 2023
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'screen_streamer'
 description: "A library that can stream an android, ios, etc. Flutter application's screen using WebRTC"
 homepage: 'https://github.com/peiffer-innovations/screen_streamer'
-version: '1.0.0+10'
+version: '1.0.0+11'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -10,12 +10,12 @@ dependencies:
   device_info_plus: '^9.0.2'
   flutter: 
     sdk: 'flutter'
-  flutter_background_service: '^2.4.6'
-  flutter_webrtc: '^0.9.33'
+  flutter_background_service: '^3.0.1'
+  flutter_webrtc: '^0.9.34'
   logging: '^1.2.0'
   sdp_transform: '^0.3.2'
   web_socket_channel: '^2.4.0'
-  web_socket_channel_connect: '^1.0.1+6'
+  web_socket_channel_connect: '^1.0.2'
 
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `flutter_background_service`: 2.4.6 --> 3.0.1
  * `flutter_webrtc`: 0.9.33 --> 0.9.34
  * `web_socket_channel_connect`: 1.0.1+6 --> 1.0.2


Analysis Successful



