### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0+29] - January 2, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.0+28] - December 5, 2023
 
 * Automated dependency updates
@@ -141,6 +146,7 @@
 ## [1.0.0] - April 3rd, 2023
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'screen_streamer'
 description: "A library that can stream an android, ios, etc. Flutter application's screen using WebRTC"
 homepage: 'https://github.com/peiffer-innovations/screen_streamer'
-version: '1.0.0+28'
+version: '1.0.0+29'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -14,7 +14,7 @@ dependencies:
   flutter_webrtc: '^0.9.47'
   logging: '^1.2.0'
   sdp_transform: '^0.3.2'
-  web_socket_channel: '^2.4.0'
+  web_socket_channel: '^2.4.1'
   web_socket_channel_connect: '^1.0.3'
 
 dev_dependencies: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `web_socket_channel`: 2.4.0 --> 2.4.1


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use 'flutter config --no-animations'.  ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-analytics.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Note: web is pinned to version 0.3.0 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on web 0.3.0 and web_socket_channel >=2.4.1 depends on web ^0.4.0, flutter_test from sdk is incompatible with web_socket_channel >=2.4.1.
So, because screen_streamer depends on both web_socket_channel ^2.4.1 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on web_socket_channel: flutter pub add web_socket_channel:^2.4.0

```



