### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.1+1] - February 6, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.1] - January 3rd, 2024
 
 * Removed unnecessary `web_socket_channel_connect` dependency
@@ -146,6 +151,7 @@
 ## [1.0.0] - April 3rd, 2023
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,27 +1,27 @@
 name: 'screen_streamer'
 description: "A library that can stream an android, ios, etc. Flutter application's screen using WebRTC"
 homepage: 'https://github.com/peiffer-innovations/screen_streamer'
-version: '1.0.1'
+version: '1.0.1+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  device_info_plus: '^9.1.1'
-  flutter:
+dependencies: 
+  device_info_plus: '^9.1.2'
+  flutter: 
     sdk: 'flutter'
   flutter_background_service: '^5.0.5'
-  flutter_webrtc: '^0.9.47'
+  flutter_webrtc: '^0.9.48+hotfix.1'
   logging: '^1.2.0'
   sdp_transform: '^0.3.2'
   web_socket_channel: '^2.4.0'
 
-dev_dependencies:
+dev_dependencies: 
   flutter_lints: '^3.0.1'
-  flutter_test:
+  flutter_test: 
     sdk: 'flutter'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'
@@ -46,6 +46,4 @@ ignore_updates:
   - 'typed_data'
   - 'vector_math'
   - 'webdriver'
-  # The "web" package is locked by flutter_test and web_socket_channel 2.4.1 is
-  # not compatible with Flutter 3.16 due to that.
   - 'web_socket_channel'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `device_info_plus`: 9.1.1 --> 9.1.2
  * `flutter_webrtc`: 0.9.47 --> 0.9.48+hotfix.1


Analysis Successful



