### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.1+8] - October 29, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.1+7] - May 14, 2024
 
 * Automated dependency updates
@@ -181,40 +186,3 @@
 ## [1.0.0] - April 3rd, 2023
 
 * Initial release
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/receiver/pubspec.yaml
+++ b/examples/receiver/pubspec.yaml
@@ -1,21 +1,21 @@
 name: 'receiver'
 publish_to: 'none'
-version: '1.0.0+3'
+version: '1.0.0+4'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
-  flutter: 
+dependencies:
+  flutter:
     sdk: 'flutter'
-  logging: '^1.2.0'
-  screen_streamer: 
+  logging: '^1.3.0'
+  screen_streamer:
     path: '../../'
 
-dev_dependencies: 
-  flutter_lints: '^4.0.0'
-  flutter_test: 
+dev_dependencies:
+  flutter_lints: '^5.0.0'
+  flutter_test:
     sdk: 'flutter'
 
-flutter: 
+flutter:
   uses-material-design: true

--- a/examples/sender/pubspec.yaml
+++ b/examples/sender/pubspec.yaml
@@ -1,21 +1,21 @@
 name: 'sender'
 publish_to: 'none'
-version: '1.0.0+3'
+version: '1.0.0+4'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
-  flutter: 
+dependencies:
+  flutter:
     sdk: 'flutter'
-  logging: '^1.2.0'
-  screen_streamer: 
+  logging: '^1.3.0'
+  screen_streamer:
     path: '../../'
 
-dev_dependencies: 
-  flutter_lints: '^4.0.0'
-  flutter_test: 
+dev_dependencies:
+  flutter_lints: '^5.0.0'
+  flutter_test:
     sdk: 'flutter'
 
-flutter: 
+flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,53 +1,47 @@
 name: 'screen_streamer'
 description: "A library that can stream an android, ios, etc. Flutter application's screen using WebRTC"
 homepage: 'https://github.com/peiffer-innovations/screen_streamer'
-version: '1.0.1+7'
+version: '1.0.1+8'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
-  device_info_plus: '^10.1.0'
-  flutter: 
+dependencies:
+  device_info_plus: '^11.1.0'
+  flutter:
     sdk: 'flutter'
-  flutter_background_service: '^5.0.5'
-  flutter_webrtc: '^0.10.6'
-  logging: '^1.2.0'
+  flutter_background_service: '^5.0.10'
+  flutter_webrtc: '^0.12.1+hotfix.1'
+  logging: '^1.3.0'
   sdp_transform: '^0.3.2'
   web_socket_channel: '^2.4.0'
 
-dev_dependencies: 
-  flutter_lints: '^4.0.0'
-  flutter_test: 
+dev_dependencies:
+  flutter_lints: '^5.0.0'
+  flutter_test:
     sdk: 'flutter'
 
 permittedLicenses:
-  - Apache-2.0
-  - BSD-2-Clause
-  - BSD-3-Clause
-  - MIT
-  - MIT-Modern-Variant
-  - MPL-2.0
-  - Zlib
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'MIT-Modern-Variant'
+  - 'MPL-2.0'
+  - 'Zlib'
 
-# The [license_checker](https://pub.dev/packages/license_checker) package cannot
-# detect the built in Flutter packages because they aren't published to pub.dev
-# and do not have a LICENSE file in their respective folders.  So this section
-# informs the license_checker that all the built in Flutter packages all have
-# the same BSD-3-Clause license as Flutter itself. 
-packageLicenseOverride: 
-  flutter: BSD-3-Clause
-  flutter_driver: BSD-3-Clause
-  flutter_goldens: BSD-3-Clause
-  flutter_localizations: BSD-3-Clause
-  flutter_web_plugins: BSD-3-Clause
-  flutter_test: BSD-3-Clause
-  fuchsia_remote_debug_protocol: BSD-3-Clause
-  integration_test: BSD-3-Clause
-  rxdart: Apache-2.0
+packageLicenseOverride:
+  flutter: 'BSD-3-Clause'
+  flutter_driver: 'BSD-3-Clause'
+  flutter_goldens: 'BSD-3-Clause'
+  flutter_localizations: 'BSD-3-Clause'
+  flutter_web_plugins: 'BSD-3-Clause'
+  flutter_test: 'BSD-3-Clause'
+  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
+  integration_test: 'BSD-3-Clause'
+  rxdart: 'Apache-2.0'
 
 ignore_updates:
- 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `device_info_plus`: 10.1.0 --> 11.1.0
  * `flutter_background_service`: 5.0.5 --> 5.0.10
  * `flutter_webrtc`: 0.10.6 --> 0.12.1+hotfix.1
  * `logging`: 1.2.0 --> 1.3.0

dev_dependencies:
  * `flutter_lints`: 4.0.0 --> 5.0.0


Analysis Successful


dependencies:
  * `logging`: 1.2.0 --> 1.3.0

dev_dependencies:
  * `flutter_lints`: 4.0.0 --> 5.0.0


Analysis Successful


dependencies:
  * `logging`: 1.2.0 --> 1.3.0

dev_dependencies:
  * `flutter_lints`: 4.0.0 --> 5.0.0


Analysis Successful

