### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+7] - February 11, 2025
+
+* Automated dependency updates
+
+
 ## [1.0.2+6] - February 4, 2025
 
 * Automated dependency updates

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: 'screen_streamer'
 description: "A library that can stream an android, ios, etc. Flutter application's screen using WebRTC"
 homepage: 'https://github.com/peiffer-innovations/screen_streamer'
-version: '1.0.2+6'
+version: '1.0.2+7'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  device_info_plus: '^11.2.2'
+  device_info_plus: '^11.3.0'
   flutter:
     sdk: 'flutter'
   flutter_background_service: '^5.1.0'
-  flutter_webrtc: '^0.12.7'
+  flutter_webrtc: '^0.12.8'
   logging: '^1.3.0'
   sdp_transform: '^0.3.2'
   web_socket_channel: '^3.0.1'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `device_info_plus`: 11.2.2 --> 11.3.0
  * `flutter_webrtc`: 0.12.7 --> 0.12.8


Analysis Successful



